### PR TITLE
Update popUp message on export

### DIFF
--- a/src/HeatManager.Core/Services/FileServices/ChartExporter.cs
+++ b/src/HeatManager.Core/Services/FileServices/ChartExporter.cs
@@ -53,6 +53,7 @@ public class ChartExporter() : IChartExporter
                 await sourceStream.CopyToAsync(destinationStream);
 
                 Console.WriteLine($"Chart image saved successfully to {file.Path}");
+                await ShowStatusNotification("Chart exported successfully", false);
 
             }
             else
@@ -156,7 +157,6 @@ public class ChartExporter() : IChartExporter
             if (skChart != null)
             {
                 await Export(skChart, filenamePrefix);
-                await ShowStatusNotification("Chart exported successfully", false);
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
I just changed where the pop-up message method is called on export chart. Because with the old order if the user cancel the procedure through the fiel dialog a wrong message was popping 